### PR TITLE
Remove mention of PR dry-runs from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We are using [Peribolos](https://github.com/kubernetes/test-infra/tree/master/pr
 
 ## Automation
 
-Travis runs *peribolos* on every PR to master (dry run) and every push to master.
+Travis runs *peribolos* on every push to master.
 
 ## Initial Config Dump
 


### PR DESCRIPTION
Removed peribolos dry-run on pull-requests. This feature was meant to ensure that the config could be applied. However it does not seem to work reliably.

- Disabled PR builds in travis
- Removed PR build checks in the branch protection rules
- Updated readme (content of this PR)