### PR TITLE
add culmat to org admins

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,7 +23,6 @@ orgs:
     - arburk
     - baloise-incubator-bot
     - CookieMonster70
-    - culmat
     - daniel-st
     - danielgrob
     - Dr-Tech81

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,7 @@ orgs:
     admins:
     - baopso
     - christiansiegel
+    - culmat
     - hirsch88
     - incubator-tekton
     - joachimprinzbach
@@ -86,6 +87,7 @@ orgs:
         - baopso
         members:
         - christiansiegel
+        - culmat
         - hirsch88
         - joachimprinzbach
         - MarkusTiede


### PR DESCRIPTION
hi @MarkusTiede - I am trying to figure out why the confluence mirror hook does not work. Would be great to have access to the webhook config and status

## Config changes proposed in this pull request
- add culmat to org admins
