### PR TITLE
Replace JohnnyGoodNews with jstammer in config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -54,7 +54,7 @@ orgs:
     - hannah-mat
     - janineKleessen
     - jacnguymesoneer
-    - JohnnyGoodNews
+    - jstammer
     - jordilaforge
     - JasperDeLanghe
     - l0r5


### PR DESCRIPTION
## Config changes proposed in this pull request
- switching the membership to my "business" github account (actual lastname but without cat profile pics 🥹)
- needed because I don't want to burn through company copilot tokens in hobby projects

## For new organization members 

### I acknowledge that
- [x] I have **read and understood the [Open Source Guidelines](https://baloise.github.io/open-source/docs/arc42/)**
- [x] I agree to **act accordingly (with due dilligence) to our guidelines**
- [x] I have **no open questions** regarding the topics covered (please delete the "open questions" section)

### Open questions
- **NOTE**: would you be so kind to also invite the account `jstammer` instead for copilot usage? (left it with this account for reasons stated above)
